### PR TITLE
Fix sub-paths for GitHub Pages deployment

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -2,12 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>AI-Agent Statistics</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://github.com/kaakaa/ai-agent-statistics/",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/ai-agent-statistics/',
   plugins: [react()],
   optimizeDeps: {
     include: ['@emotion/react'],


### PR DESCRIPTION
Update configuration to handle sub-paths in GitHub Pages deployment

* **webapp/vite.config.ts**
  - Add `base` property set to `/ai-agent-statistics/` in the `defineConfig` function.

* **webapp/index.html**
  - Update the `src` attribute of the `<script>` tag to use a relative path for `main.tsx`.
  - Update the `title` tag to "AI-Agent Statistics".

* **webapp/package.json**
  - Add `homepage` field set to "https://github.com/kaakaa/ai-agent-statistics/".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kaakaa/ai-agent-statistics/pull/2?shareId=b807c154-f8ec-4183-9325-98fbbb6c70f1).