### PR TITLE
Enable time range specification for GitHub GraphQL query

### DIFF
--- a/src/ai_agent_statistics/__main__.py
+++ b/src/ai_agent_statistics/__main__.py
@@ -27,15 +27,25 @@ def run(token: str, start_date: str = None, end_date: str = None):
     store = Store("store.db")
     client = GitHubGQLClient(token)
 
+    date_query = ''
+    if start_date and end_date:
+        date_query = f"created:{start_date}..{end_date}"
+    elif start_date:
+        date_query = f"created:>={start_date}"
+    elif end_date:
+        date_query = f"created:<={end_date}"
+
     callback = partial(save, store, [])
-    for author in ["devin-ai-integration[bot]", "openhands-agent"]:
-         client.query_pr(author, callback, start_date, end_date)
+    for author in ["devin-ai-integration[bot]", "openhands-agent", "devloai"]:
+         client.query_pr(author, callback, additional_query=date_query)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="GitHub PR Statistics")
-    parser.add_argument("token", help="GitHub token")
+    parser.add_argument("--token", help="GitHub token")
     parser.add_argument("--start-date", help="Start date for the query (YYYY-MM-DD)")
     parser.add_argument("--end-date", help="End date for the query (YYYY-MM-DD)")
     args = parser.parse_args()
 
-    run(args.token, args.start_date, args.end_date)
+    token = args.token or os.getenv("GITHUB_TOKEN")
+
+    run(token, args.start_date, args.end_date)

--- a/src/ai_agent_statistics/github_gql.py
+++ b/src/ai_agent_statistics/github_gql.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 search_pr_query = query = """
 query ($search_query: String!, $after: String) {
     search(query: $search_query, type: ISSUE, first: 5, after:$after) {
+        issueCount
         edges {
             node {
                 ... on PullRequest {
@@ -59,20 +60,16 @@ class GitHubGQLClient:
             "Content-Type": "application/json",
         }
     
-    def query_pr(self, author_name: str, callback, start_date: str = None, end_date: str = None) -> None:
+    def query_pr(self, author_name: str, callback, additional_query: str | None = None) -> None:
         has_next_page = True
         after_cursor = None
+        total_issue_count = -1
         count = 0
 
         while has_next_page:
-            logger.info(f"[{count+1}] Querying PRs for '{author_name}' after '{after_cursor}'")
-            date_filter = ""
-            if start_date:
-                date_filter += f" created:>={start_date}"
-            if end_date:
-                date_filter += f" created:<={end_date}"
+            logger.info(f"[{count+1}/{total_issue_count}] Querying PRs for '{author_name}' after '{after_cursor}'")
             variables = {
-                "search_query": f"author:{author_name} type:pr{date_filter}",
+                "search_query": f"author:{author_name} type:pr {additional_query}",
                 "after": after_cursor
             }
 
@@ -93,6 +90,8 @@ class GitHubGQLClient:
                 for pr in [PullRequest.model_validate(pr["node"]) for pr in ret["data"]["search"]["edges"]]:
                     callback(pr)
 
+                if total_issue_count == -1:
+                    total_issue_count = ret["data"]["search"]["issueCount"]
                 page_info = ret["data"]["search"]["pageInfo"]
                 has_next_page = page_info["hasNextPage"]
                 after_cursor = page_info["endCursor"]


### PR DESCRIPTION
Add CLI argument parsing for specifying time range for GitHub GraphQL query.

* **CLI Argument Parsing**: Add `argparse` to parse `--start-date` and `--end-date` arguments in `src/ai_agent_statistics/__main__.py`.
* **Update `run` function**: Modify `run` function to accept `start_date` and `end_date` arguments and pass them to `client.query_pr`.
* **GraphQL Query Update**: Update `query_pr` method in `src/ai_agent_statistics/github_gql.py` to accept `start_date` and `end_date` parameters and include time range filters in the GraphQL query.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kaakaa/ai-agent-statistics/pull/4?shareId=3c510a63-3a57-4e75-9e34-7db82351595e).